### PR TITLE
Add support for processor architectures other than x86

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,8 @@
 [build]
 rustflags = ["-C", "target-cpu=native"]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C",
+    "debug-assertions=false",
+]

--- a/src/seekstorm/commit.rs
+++ b/src/seekstorm/commit.rs
@@ -2,16 +2,14 @@ use ahash::AHashMap;
 use memmap2::Mmap;
 use num::FromPrimitive;
 use num_format::{Locale, ToFormattedString};
-use std::{
-    arch::x86_64::{_blsr_u64, _mm_tzcnt_64},
-    io::{Seek, SeekFrom, Write},
-};
+use std::io::{Seek, SeekFrom, Write};
 
 use crate::{
     add_result::{
         decode_positions_multiterm_multifield, decode_positions_multiterm_singlefield,
         get_next_position_multifield, get_next_position_singlefield,
     },
+    compatible::{_blsr_u64, _mm_tzcnt_64},
     compress_postinglist::compress_postinglist,
     index::{
         update_list_max_impact_score, update_stopwords_posting_counts, warmup, AccessType,

--- a/src/seekstorm/compatible.rs
+++ b/src/seekstorm/compatible.rs
@@ -1,0 +1,21 @@
+#[cfg(target_arch = "x86_64")]
+pub use std::arch::x86_64::{_blsr_u64, _lzcnt_u32, _mm_tzcnt_64};
+
+#[cfg(not(target_arch = "x86_64"))]
+pub unsafe fn _mm_tzcnt_64(x: u64) -> i64 {
+    x.trailing_zeros() as i64
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+pub unsafe fn _blsr_u64(x: u64) -> u64 {
+    if x == 0 {
+        x
+    } else {
+        x & (!(1 << x.trailing_zeros()))
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+pub unsafe fn _lzcnt_u32(x: u32) -> u32 {
+    x.leading_zeros()
+}

--- a/src/seekstorm/compress_postinglist.rs
+++ b/src/seekstorm/compress_postinglist.rs
@@ -1,9 +1,10 @@
-use std::{arch::x86_64::_lzcnt_u32, cmp};
+use std::cmp;
 
 use smallvec::SmallVec;
 
 use crate::{
     add_result::{decode_positions_commit, B, DOCUMENT_LENGTH_COMPRESSION, K, SIGMA},
+    compatible::_lzcnt_u32,
     index::{CompressionType, Index, SimilarityType, STOPWORDS, STOP_BIT},
     utils::{
         block_copy, read_u16_ref, read_u32_ref, write_u16, write_u16_ref, write_u32_ref,

--- a/src/seekstorm/intersection.rs
+++ b/src/seekstorm/intersection.rs
@@ -1,5 +1,6 @@
 use crate::{
     add_result::add_result_multiterm_multifield,
+    compatible::{_blsr_u64, _mm_tzcnt_64},
     index::{
         AccessType, CompressionType, Index, NonUniquePostingListObjectQuery,
         PostingListObjectQuery, SORT_FLAG, SPEEDUP_FLAG,
@@ -12,7 +13,6 @@ use crate::{
 use ahash::AHashSet;
 use num_traits::FromPrimitive;
 use std::{
-    arch::x86_64::{_blsr_u64, _mm_tzcnt_64},
     cmp,
     cmp::Ordering as OtherOrdering,
     sync::{

--- a/src/seekstorm/lib.rs
+++ b/src/seekstorm/lib.rs
@@ -113,6 +113,8 @@
 //! }
 //! ```
 
+pub(crate) mod compatible;
+
 pub(crate) mod add_result;
 /// Commit moves indexed documents from the intermediate uncompressed data structure in RAM
 /// to the final compressed data structure on disk.

--- a/src/seekstorm/single.rs
+++ b/src/seekstorm/single.rs
@@ -1,13 +1,11 @@
-use std::{
-    arch::x86_64::{_blsr_u64, _mm_tzcnt_64},
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
 };
 
 use crate::{
     add_result::{add_result_singleterm_multifield, PostingListObjectSingle},
+    compatible::{_blsr_u64, _mm_tzcnt_64},
     index::{
         AccessType, BlockObjectIndex, CompressionType, Index, NonUniquePostingListObjectQuery,
         PostingListObjectQuery, SORT_FLAG, SPEEDUP_FLAG,
@@ -38,7 +36,10 @@ pub(crate) async fn single_docid<'a>(
     let block_score = blo.max_block_score;
     let filtered = !not_query_list.is_empty() || field_filter_set.len() > 0;
     if SPEEDUP_FLAG
-        && topk_candidates.current_heap_size == top_k && block_score <= topk_candidates._elements[0].score && (!filtered || result_type == &ResultType::Topk) {
+        && topk_candidates.current_heap_size == top_k
+        && block_score <= topk_candidates._elements[0].score
+        && (!filtered || result_type == &ResultType::Topk)
+    {
         return;
     }
 
@@ -338,7 +339,7 @@ pub(crate) async fn single_blockid<'a>(
                 )
                 .await;
             }
-        } 
+        }
     }
 
     if SORT_FLAG && SPEEDUP_FLAG {

--- a/src/seekstorm/union.rs
+++ b/src/seekstorm/union.rs
@@ -2,6 +2,7 @@ use crate::{
     add_result::{
         add_result_multiterm_multifield, add_result_singleterm_multifield, PostingListObjectSingle,
     },
+    compatible::{_blsr_u64, _mm_tzcnt_64},
     index::{
         AccessType, CompressionType, Index, NonUniquePostingListObjectQuery,
         PostingListObjectQuery, QueueObject,
@@ -16,10 +17,7 @@ use crate::{
 use ahash::AHashSet;
 use num_traits::FromPrimitive;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{
-    arch::x86_64::{_blsr_u64, _mm_tzcnt_64},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use async_recursion::async_recursion;
 


### PR DESCRIPTION
This PR adds support for processor architectures other than x86 so that SeekStorm can be built and ran on a wider range of platforms.