### PR TITLE
Fix server command line example (use real space)

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ Move the decompressed wiki-articles.json to the release directory
 cd target/release
 ```
 ```
-./seekstorm_server local_ip="0.0.0.0" local_port=80
+./seekstorm_server local_ip="0.0.0.0" local_port=80
 ```
 
 **Indexing** 


### PR DESCRIPTION
In the example line we had a strange, space lookalike `%C2%A0` instead of a standard `%20` space.

This strange char was making the `parms` parsing broken: `"local_ip=0.0.0.0\u{a0}local_port=8090"` was parsed as a single argument.