### PR TITLE
Fix silent deletion due to asynchronous hysteresis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ debug/
 target/
 seekstorm/tests/index_test/
 seekstorm/tests/index_facet_test/
+seekstorm/tests/index_delete_*/
 .vscode/
 .idea
 

--- a/seekstorm/src/index.rs
+++ b/seekstorm/src/index.rs
@@ -4574,8 +4574,12 @@ impl Index {
     pub async fn current_doc_count(&self) -> usize {
         let mut current_doc_count = 0;
         for shard in self.shard_vec.iter() {
-            current_doc_count +=
-                shard.read().await.indexed_doc_count - shard.read().await.delete_hashset.len();
+            // saturating: deletes are recorded against allocated docids and
+            // may transiently outnumber the indexed counter (async indexing).
+            let shard_ref = shard.read().await;
+            current_doc_count += shard_ref
+                .indexed_doc_count
+                .saturating_sub(shard_ref.delete_hashset.len());
         }
         current_doc_count
     }
@@ -4584,8 +4588,10 @@ impl Index {
     pub async fn uncommitted_doc_count(&self) -> usize {
         let mut uncommitted_doc_count = 0;
         for shard in self.shard_vec.iter() {
-            uncommitted_doc_count +=
-                shard.read().await.indexed_doc_count - shard.read().await.committed_doc_count;
+            let shard_ref = shard.read().await;
+            uncommitted_doc_count += shard_ref
+                .indexed_doc_count
+                .saturating_sub(shard_ref.committed_doc_count);
         }
         uncommitted_doc_count
     }
@@ -5098,6 +5104,8 @@ pub trait DeleteDocument {
 ///   ⚠️ Use search or get_iterator first to obtain a valid doc_id. Document IDs are not guaranteed to be continuous and gapless!
 ///
 /// Immediately effective, independent of commit.
+/// Only already allocated docids are accepted; clear_index invalidates old
+/// docids and reuses the namespace.
 /// Index space used by deleted documents is not reclaimed (until compaction is implemented), but result_count_total is updated.
 /// By manually deleting the delete.bin file the deleted documents can be recovered (until compaction).
 /// Deleted documents impact performance, especially but not limited to counting (Count, TopKCount). They also increase the size of the index (until compaction is implemented).
@@ -5105,19 +5113,32 @@ pub trait DeleteDocument {
 /// BM25 scores are not updated (until compaction is implemented), but the impact is minimal.
 impl DeleteDocument for IndexArc {
     async fn delete_document(&self, docid: u64) {
-        let index_ref = self.read().await;
-        let shard_number = index_ref.shard_number as u64;
-        let shard_id = docid % shard_number;
-        let doc_id = docid / shard_number;
-
-        let mut shard_mut = index_ref.shard_vec[shard_id as usize].write().await;
-
-        if doc_id as usize >= shard_mut.indexed_doc_count {
+        // Validity bound must be the synchronously allocated docid namespace,
+        // not the per-shard indexed counter: the latter is updated by the
+        // async index task (and by commit), so it lags behind and would
+        // silently drop deletes of uncommitted documents. u64 comparison
+        // throughout: narrowing `docid` to usize would truncate on 32-bit.
+        let docid_global = self.read().await.docid_global.clone();
+        let allocated_docid_count = *docid_global.read().await as u64;
+        if docid >= allocated_docid_count {
             return;
         }
-        if shard_mut.delete_hashset.insert(doc_id as usize) {
+        // Clone what is needed, then drop the read guard before taking the
+        // shard write lock, keeping the critical section minimal.
+        let (shard_number, shard) = {
+            let index_ref = self.read().await;
+            (
+                index_ref.shard_number as u64,
+                index_ref.shard_vec[(docid % index_ref.shard_number as u64) as usize].clone(),
+            )
+        };
+        let docid_local = docid / shard_number;
+
+        let mut shard_mut = shard.write().await;
+
+        if shard_mut.delete_hashset.insert(docid_local as usize) {
             let mut buffer: [u8; 8] = [0; 8];
-            write_u64(doc_id, &mut buffer, 0);
+            write_u64(docid_local, &mut buffer, 0);
             let _ = shard_mut.delete_file.write(&buffer);
             let _ = shard_mut.delete_file.flush();
         }
@@ -5134,6 +5155,8 @@ pub trait DeleteDocuments {
 /// Delete documents from index by document id
 /// Document ID can by obtained by search.
 /// Immediately effective, independent of commit.
+/// Only already allocated docids are accepted; clear_index invalidates old
+/// docids and reuses the namespace.
 /// Index space used by deleted documents is not reclaimed (until compaction is implemented), but result_count_total is updated.
 /// By manually deleting the delete.bin file the deleted documents can be recovered (until compaction).
 /// Deleted documents impact performance, especially but not limited to counting (Count, TopKCount). They also increase the size of the index (until compaction is implemented).

--- a/seekstorm/tests/delete_uncommitted.rs
+++ b/seekstorm/tests/delete_uncommitted.rs
@@ -1,0 +1,147 @@
+//! Regression tests: deletes of not-yet-committed documents must survive
+//! the next commit instead of being silently dropped.
+//!
+//! Self-contained (own index directory), deterministic, no sleeps.
+
+use seekstorm::commit::Commit;
+use seekstorm::index::{
+    AccessType, Close, Clustering, DeleteDocuments, DocumentCompression, FrequentwordType,
+    IndexDocuments, IndexMetaObject, LexicalSimilarity, NgramSet, StemmerType, StopwordType,
+    TokenizerType, create_index,
+};
+use seekstorm::search::{QueryRewriting, QueryType, ResultType, Search, SearchMode};
+use seekstorm::vector::Inference;
+use std::{fs, path::Path};
+
+fn meta() -> IndexMetaObject {
+    IndexMetaObject {
+        id: 0,
+        name: "delete_uncommitted".into(),
+        lexical_similarity: LexicalSimilarity::Bm25f,
+        tokenizer: TokenizerType::UnicodeAlphanumeric,
+        stemmer: StemmerType::None,
+        stop_words: StopwordType::None,
+        frequent_words: FrequentwordType::None,
+        ngram_indexing: NgramSet::SingleTerm as u8,
+        document_compression: DocumentCompression::Snappy,
+        access_type: AccessType::Mmap,
+        spelling_correction: None,
+        query_completion: None,
+        clustering: Clustering::None,
+        inference: Inference::None,
+    }
+}
+
+fn schema() -> Vec<seekstorm::index::SchemaField> {
+    serde_json::from_str(
+        r#"[{"field":"title","field_type":"Text","store":true,"index_lexical":true}]"#,
+    )
+    .unwrap()
+}
+
+fn doc(title: &str) -> seekstorm::index::Document {
+    serde_json::from_str(&format!(r#"{{"title":"{title}"}}"#)).unwrap()
+}
+
+async fn count(
+    index: &seekstorm::index::IndexArc,
+    query: &str,
+    uncommitted: bool,
+) -> usize {
+    index
+        .search(
+            query.into(),
+            None,
+            QueryType::Union,
+            SearchMode::Lexical,
+            false,
+            0,
+            100,
+            ResultType::TopkCount,
+            uncommitted,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            QueryRewriting::SearchOnly,
+        )
+        .await
+        .result_count_total
+}
+
+async fn fresh(dir: &str) -> seekstorm::index::IndexArc {
+    let path = Path::new(dir);
+    let _ = fs::remove_dir_all(path);
+    create_index(path, meta(), &schema(), &Vec::new(), 11, true, None)
+        .await
+        .unwrap()
+}
+
+/// Delete-before-commit must stick: the document stays gone after commit.
+#[tokio::test]
+async fn delete_uncommitted_survives_commit() {
+    let index = fresh("tests/index_delete_uncommitted/").await;
+    index
+        .index_documents(vec![doc("hello world"), doc("foo bar")])
+        .await;
+    index.delete_documents(vec![0]).await;
+    // Must not underflow/panic while the async index task is still running.
+    let _ = index.read().await.current_doc_count().await;
+    index.commit().await;
+    assert_eq!(count(&index, "hello", false).await, 0);
+    assert_eq!(index.read().await.current_doc_count().await, 1);
+    index.close().await;
+}
+
+/// Control: delete-after-commit keeps working as before.
+#[tokio::test]
+async fn delete_committed_control() {
+    let index = fresh("tests/index_delete_committed/").await;
+    index
+        .index_documents(vec![doc("hello world"), doc("foo bar")])
+        .await;
+    index.commit().await;
+    index.delete_documents(vec![0]).await;
+    index.commit().await;
+    assert_eq!(count(&index, "hello", false).await, 0);
+    assert_eq!(index.read().await.current_doc_count().await, 1);
+    index.close().await;
+}
+
+/// Out-of-range deletes stay silent no-ops: no panic, counts unchanged.
+#[tokio::test]
+async fn delete_out_of_range_ignored() {
+    let index = fresh("tests/index_delete_range/").await;
+    index
+        .index_documents(vec![doc("hello world"), doc("foo bar")])
+        .await;
+    index.commit().await;
+    index.delete_documents(Vec::new()).await;
+    index.delete_documents(vec![u64::MAX]).await;
+    index.delete_documents(vec![999_999]).await;
+    index.delete_documents(vec![0, 0, 0]).await;
+    index.commit().await;
+    assert_eq!(count(&index, "hello", false).await, 0);
+    assert_eq!(index.read().await.current_doc_count().await, 1);
+    index.close().await;
+}
+
+/// clear_index reuses the docid namespace: a stale pre-clear docid addresses
+/// whatever new document reuses that number (documents id-reuse semantics).
+#[tokio::test]
+async fn delete_reused_docid_after_clear() {
+    let index = fresh("tests/index_delete_clear/").await;
+    index
+        .index_documents(vec![doc("hello world"), doc("foo bar")])
+        .await;
+    index.commit().await;
+    index.write().await.clear_index().await;
+    index
+        .index_documents(vec![doc("alphaone"), doc("betaone")])
+        .await;
+    index.delete_documents(vec![0]).await;
+    index.commit().await;
+    assert_eq!(count(&index, "alphaone", false).await, 0);
+    assert_eq!(count(&index, "betaone", false).await, 1);
+    index.close().await;
+}


### PR DESCRIPTION
`delete_documents` on an indexed-but-uncommitted document is silently
ignored, and the document reappears after the next `commit()` —
contradicting the documented "Immediately effective, independent of commit".

## The bug

```rust
let index = create_index(path, meta, &fields, &vec![], 11, true, None).await?;
index.index_documents(vec![doc("hello"), doc("world")]).await;
index.delete_documents(vec![0]).await;
index.commit().await;
// expected: "hello" gone. actual: still there, current_doc_count() == 2.
```

Deleting after committing first works, and re-deleting after the
resurrecting commit works too — so the docid is valid; the pre-commit
delete is what gets lost.

`index_documents` only spawns the work onto `INDEX_RUNTIME` (`index.rs:5301`);
the per-shard `indexed_doc_count` is updated inside that task (`:5519`).
But the range guard in `delete_document` reads that same counter (`:5115`):

```rust
if doc_id as usize >= shard_mut.indexed_doc_count {
    return;
}
```

Pre-commit the counter is still 0, so the delete is discarded before it
reaches the hashset/`delete.bin` (`delete.bin` stays 0 bytes; a post-commit
delete writes 8 bytes as expected).

## Fix

Guard against the synchronously allocated `docid_global` upper bound
instead of the lagging per-shard counter (compared in `u64` throughout).
Companion hardening: `saturating_sub` in `current/uncommitted_doc_count`,
since deletes may now transiently outnumber the indexed counter.

Out-of-range ids are still silently ignored; `clear_index`/multi-shard
semantics unchanged (see tests).

## Tests

New `seekstorm/tests/delete_uncommitted.rs` (4/4 green); full suite and
clippy clean on touched files:

- delete_uncommitted_survives_commit (the repro above)
- delete_committed_control
- delete_out_of_range_ignored (`u64::MAX`, far-future ids, empty vec, triple-delete)
- delete_reused_docid_after_clear (documents id-reuse semantics)

Note: after `clear_index` resets the docid namespace, a stale pre-clear
docid deletes whatever new document reuses that number — same id-reuse
semantics as before, flagging so it's on record.
