### PR TITLE
Fix Union Count ignoring deleted documents

### DIFF
--- a/seekstorm/src/union.rs
+++ b/seekstorm/src/union.rs
@@ -1179,7 +1179,9 @@ pub(crate) async fn union_docid_2<'a>(
     matching_blocks: &mut i32,
     query_term_count: usize,
 ) {
-    let filtered = !not_query_list.is_empty() || !field_filter_set.is_empty();
+    let filtered = !not_query_list.is_empty()
+        || !field_filter_set.is_empty()
+        || !shard.delete_hashset.is_empty();
     let mut count = 0;
     if filtered {
         single_blockid(

--- a/seekstorm/tests/union_delete_consistency.rs
+++ b/seekstorm/tests/union_delete_consistency.rs
@@ -1,0 +1,127 @@
+//! Regression tests: multi-term `Union` (OR) `result_count_total` must exclude
+//! deleted documents, matching `results.len()`.
+//!
+//! Root cause was `union_docid_2` (seekstorm/src/union.rs) computing the
+//! total from raw `posting_count`s whenever no NOT/field filter was present,
+//! ignoring `delete_hashset` (commit does not rewrite posting lists).
+//! Depends on the single-term Count fix (#71) for the per-term slow path.
+//!
+//! Self-contained (own index directory), deterministic, no sleeps.
+
+use seekstorm::commit::Commit;
+use seekstorm::index::{
+    AccessType, Close, Clustering, DeleteDocuments, DocumentCompression, FrequentwordType,
+    IndexDocuments, IndexMetaObject, LexicalSimilarity, NgramSet, StemmerType, StopwordType,
+    TokenizerType, create_index,
+};
+use seekstorm::search::{QueryRewriting, QueryType, ResultType, Search, SearchMode};
+use seekstorm::vector::Inference;
+use std::{fs, path::Path};
+
+fn meta() -> IndexMetaObject {
+    IndexMetaObject {
+        id: 0,
+        name: "union_delete_consistency".into(),
+        lexical_similarity: LexicalSimilarity::Bm25f,
+        tokenizer: TokenizerType::UnicodeAlphanumeric,
+        stemmer: StemmerType::None,
+        stop_words: StopwordType::None,
+        frequent_words: FrequentwordType::None,
+        ngram_indexing: NgramSet::SingleTerm as u8,
+        document_compression: DocumentCompression::Snappy,
+        access_type: AccessType::Mmap,
+        spelling_correction: None,
+        query_completion: None,
+        clustering: Clustering::None,
+        inference: Inference::None,
+    }
+}
+
+fn schema() -> Vec<seekstorm::index::SchemaField> {
+    serde_json::from_str(
+        r#"[{"field":"title","field_type":"Text","store":true,"index_lexical":true}]"#,
+    )
+    .unwrap()
+}
+
+fn doc(title: &str) -> seekstorm::index::Document {
+    serde_json::from_str(&format!(r#"{{"title":"{title}"}}"#)).unwrap()
+}
+
+async fn search(
+    index: &seekstorm::index::IndexArc,
+    query: &str,
+    result_type: ResultType,
+) -> seekstorm::search::ResultObject {
+    index
+        .search(
+            query.into(),
+            None,
+            QueryType::Union,
+            SearchMode::Lexical,
+            false,
+            0,
+            100,
+            result_type,
+            false,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            QueryRewriting::SearchOnly,
+        )
+        .await
+}
+
+async fn fresh(dir: &str) -> seekstorm::index::IndexArc {
+    let path = Path::new(dir);
+    let _ = fs::remove_dir_all(path);
+    create_index(path, meta(), &schema(), &Vec::new(), 11, true, None)
+        .await
+        .unwrap()
+}
+
+/// OR total must drop deleted documents (disjoint terms).
+#[tokio::test]
+async fn union_count_excludes_deleted() {
+    let index = fresh("tests/index_delete_union/").await;
+    let mut docs = vec![];
+    for i in 0..10 {
+        docs.push(doc(&format!("alpha uniq{i}")));
+    }
+    for i in 0..10 {
+        docs.push(doc(&format!("beta uniqb{i}")));
+    }
+    index.index_documents(docs).await;
+    index.commit().await;
+    index.delete_documents(vec![0, 1, 10]).await;
+    index.commit().await;
+
+    let count = search(&index, "alpha beta", ResultType::Count).await;
+    let topk_count = search(&index, "alpha beta", ResultType::TopkCount).await;
+    assert_eq!(count.result_count_total, 17);
+    assert_eq!(topk_count.result_count_total, 17);
+    assert_eq!(topk_count.results.len(), 17);
+    index.close().await;
+}
+
+/// Control: without deletes the OR fast path is untouched and exact.
+#[tokio::test]
+async fn union_count_no_deletes_control() {
+    let index = fresh("tests/index_delete_union_control/").await;
+    let mut docs = vec![];
+    for i in 0..10 {
+        docs.push(doc(&format!("alpha uniq{i}")));
+    }
+    for i in 0..10 {
+        docs.push(doc(&format!("beta uniqb{i}")));
+    }
+    index.index_documents(docs).await;
+    index.commit().await;
+
+    let count = search(&index, "alpha beta", ResultType::Count).await;
+    let topk_count = search(&index, "alpha beta", ResultType::TopkCount).await;
+    assert_eq!(count.result_count_total, 20);
+    assert_eq!(topk_count.result_count_total, 20);
+    index.close().await;
+}


### PR DESCRIPTION
## Summary
Multi-term `Union` (OR) `result_count_total` ignores deletes (`Count` and
`TopkCount` stay pre-delete, `results.len()` is right). Follow-up to
Follow-up to #66/#71: same miscount class on the OR path (`union.rs`).

## Root cause
`union_docid_2` (`union.rs:1182`) builds totals from raw `posting_count`
sum minus intersection whenever no NOT/field filter is present; commit
does not rewrite posting lists. Q3: 10+10-0=20 pre-fix, 17 post-fix.

## Fix
One line, mirroring `single_blockid`:
```rust
|| !shard.delete_hashset.is_empty()
```
No-deletes path unchanged.

## Tests
- New `union_delete_consistency.rs`: 2/2 green; main test fails without fix.
- `test.rs` 15/15, `delete_uncommitted` 4/4; clippy/fmt clean.
- Perf: no-deletes unchanged; with-deletes wrong-fast ~340us -> correct
  ~1.1ms (20k postings, debug).
