### PR TITLE
Fix realtime totals ignoring deleted documents

### DIFF
--- a/seekstorm/src/realtime_search.rs
+++ b/seekstorm/src/realtime_search.rs
@@ -1280,7 +1280,10 @@ impl Shard {
         }
 
         if result_type != &ResultType::Topk {
-            let filtered = !not_query_list.is_empty() || !field_filter_set.is_empty();
+            let filtered = !not_query_list.is_empty()
+                || !field_filter_set.is_empty()
+                || !self.delete_hashset.is_empty()
+                || !facet_filter.is_empty();
             result_count_arc.fetch_add(
                 if filtered {
                     result_count_local as usize
@@ -1928,7 +1931,7 @@ impl Shard {
         let mut result_count: i32 = 0;
 
         if result_type == &ResultType::Count {
-            self.union_count_uncommitted(&mut result_count, query_list);
+            self.union_count_uncommitted(&mut result_count, query_list, block_id);
             result_count_arc.fetch_add(result_count as usize, Ordering::Relaxed);
             return;
         }
@@ -1953,7 +1956,11 @@ impl Shard {
         &self,
         result_count: &mut i32,
         query_list: &mut [PostingListObjectQuery],
+        block_id: usize,
     ) {
+        // TODO: NOT/field/facet filters are not applied here (no params for
+        // them, unlike committed union_count); only deletes are excluded.
+        // Queries with those filters on uncommitted data may still miscount.
         query_list.sort_by(|a, b| b.posting_count.partial_cmp(&a.posting_count).unwrap());
 
         let mut result_count_local = query_list[0].posting_count;
@@ -1967,18 +1974,28 @@ impl Shard {
             if i == 0 {
                 for _p_docid in 0..item.posting_count {
                     self.get_next_docid_uncommitted(item);
-                    let docid = item.docid as usize;
-                    let byte_index = docid >> 3;
-                    let bit_index = docid & 7;
+                    let docid = (block_id << 16) | item.docid as usize;
+                    if self.delete_hashset.contains(&docid) {
+                        // Deleted docs must neither set bits (they would
+                        // shadow later terms) nor stay in the initial
+                        // posting_count-based total.
+                        result_count_local -= 1;
+                        continue;
+                    }
+                    let byte_index = item.docid as usize >> 3;
+                    let bit_index = item.docid as usize & 7;
 
                     bitmap_0[byte_index] |= 1 << bit_index;
                 }
             } else {
                 for _p_docid in 0..item.posting_count {
                     self.get_next_docid_uncommitted(item);
-                    let docid = item.docid as usize;
-                    let byte_index = docid >> 3;
-                    let bit_index = docid & 7;
+                    let docid = (block_id << 16) | item.docid as usize;
+                    if self.delete_hashset.contains(&docid) {
+                        continue;
+                    }
+                    let byte_index = item.docid as usize >> 3;
+                    let bit_index = item.docid as usize & 7;
 
                     if bitmap_0[byte_index] & (1 << bit_index) == 0 {
                         bitmap_0[byte_index] |= 1 << bit_index;
@@ -2047,7 +2064,12 @@ impl Shard {
                         &mut query_list[term_index],
                         not_query_list,
                     );
-                    if not_query_list.is_empty() && result_type != &ResultType::Topk {
+                    if not_query_list.is_empty()
+                        && field_filter_set.is_empty()
+                        && self.delete_hashset.is_empty()
+                        && facet_filter.is_empty()
+                        && result_type != &ResultType::Topk
+                    {
                         *result_count += 1;
                     }
                 } else {

--- a/seekstorm/tests/realtime_delete_consistency.rs
+++ b/seekstorm/tests/realtime_delete_consistency.rs
@@ -1,0 +1,178 @@
+//! Regression tests: realtime (`include_uncommitted = true`) totals must
+//! exclude deleted documents, for both `Count` and `TopkCount`.
+//!
+//! Root causes were in seekstorm/src/realtime_search.rs: the single-term
+//! tail redefined `filtered` without deletes/facets and fell back to the raw
+//! `posting_count`; `union_count_uncommitted` never consulted `delete_hashset`;
+//! and the `union_scan_uncommitted` single-hit branch double-counted filtered
+//! docs (callee and caller each added one).
+//! Depends on the single-term Count fix (#71) for committed reads.
+//!
+//! Self-contained (own index directory). The only waits are bounded polls
+//! for the async indexer to settle (fails loudly on timeout, no sleeps
+//! past settled state).
+
+use seekstorm::commit::Commit;
+use seekstorm::index::{
+    AccessType, Close, Clustering, DeleteDocuments, DocumentCompression, FrequentwordType,
+    IndexDocuments, IndexMetaObject, LexicalSimilarity, NgramSet, StemmerType, StopwordType,
+    TokenizerType, create_index,
+};
+use seekstorm::search::{QueryRewriting, QueryType, ResultType, Search, SearchMode};
+use seekstorm::vector::Inference;
+use std::{fs, path::Path, time::Duration};
+
+fn meta() -> IndexMetaObject {
+    IndexMetaObject {
+        id: 0,
+        name: "realtime_delete_consistency".into(),
+        lexical_similarity: LexicalSimilarity::Bm25f,
+        tokenizer: TokenizerType::UnicodeAlphanumeric,
+        stemmer: StemmerType::None,
+        stop_words: StopwordType::None,
+        frequent_words: FrequentwordType::None,
+        ngram_indexing: NgramSet::SingleTerm as u8,
+        document_compression: DocumentCompression::Snappy,
+        access_type: AccessType::Mmap,
+        spelling_correction: None,
+        query_completion: None,
+        clustering: Clustering::None,
+        inference: Inference::None,
+    }
+}
+
+fn schema() -> Vec<seekstorm::index::SchemaField> {
+    serde_json::from_str(
+        r#"[{"field":"title","field_type":"Text","store":true,"index_lexical":true}]"#,
+    )
+    .unwrap()
+}
+
+fn doc(title: &str) -> seekstorm::index::Document {
+    serde_json::from_str(&format!(r#"{{"title":"{title}"}}"#)).unwrap()
+}
+
+async fn search(
+    index: &seekstorm::index::IndexArc,
+    query: &str,
+    query_type: QueryType,
+    result_type: ResultType,
+    uncommitted: bool,
+) -> seekstorm::search::ResultObject {
+    index
+        .search(
+            query.into(),
+            None,
+            query_type,
+            SearchMode::Lexical,
+            false,
+            0,
+            100,
+            result_type,
+            uncommitted,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            QueryRewriting::SearchOnly,
+        )
+        .await
+}
+
+async fn fresh(dir: &str) -> seekstorm::index::IndexArc {
+    let path = Path::new(dir);
+    let _ = fs::remove_dir_all(path);
+    create_index(path, meta(), &schema(), &Vec::new(), 11, true, None)
+        .await
+        .unwrap()
+}
+
+/// Wait until the async indexer has settled `expected` docs (bounded).
+/// NOTE: `indexed_doc_count` is a high-water mark written when the index
+/// task *starts* (index.rs), so it cannot be used here. Settle on the
+/// observable search state instead: all docs must be visible first.
+async fn settle_search(
+    index: &seekstorm::index::IndexArc,
+    query: &str,
+    query_type: QueryType,
+    expected: usize,
+) {
+    for _ in 0..200 {
+        let r = search(
+            index,
+            query,
+            query_type.clone(),
+            ResultType::TopkCount,
+            true,
+        )
+        .await;
+        if r.result_count_total == expected && r.results.len() == expected.min(100) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("realtime search did not settle to {expected} docs in time");
+}
+
+/// Single-term realtime totals must drop a deleted uncommitted document.
+#[tokio::test]
+async fn realtime_single_count_excludes_deleted() {
+    let index = fresh("tests/index_delete_realtime_single/").await;
+    let docs: Vec<_> = (0..5).map(|i| doc(&format!("base doc{i}"))).collect();
+    index.index_documents(docs).await;
+    index.commit().await;
+    let docs: Vec<_> = (0..5).map(|i| doc(&format!("base extra{i}"))).collect();
+    index.index_documents(docs).await;
+    settle_search(&index, "base", QueryType::Union, 10).await;
+    index.delete_documents(vec![9, 0]).await;
+
+    let topk = search(
+        &index,
+        "base",
+        QueryType::Union,
+        ResultType::TopkCount,
+        true,
+    )
+    .await;
+    let count = search(&index, "base", QueryType::Union, ResultType::Count, true).await;
+    assert_eq!(topk.result_count_total, 8);
+    assert_eq!(count.result_count_total, 8);
+    index.close().await;
+}
+
+/// OR realtime totals must drop deleted uncommitted documents (no double count).
+#[tokio::test]
+async fn realtime_union_count_excludes_deleted() {
+    let index = fresh("tests/index_delete_realtime_union/").await;
+    let mut docs = vec![];
+    for i in 0..10 {
+        docs.push(doc(&format!("alpha uniq{i}")));
+    }
+    for i in 0..10 {
+        docs.push(doc(&format!("beta uniqb{i}")));
+    }
+    index.index_documents(docs).await;
+    settle_search(&index, "alpha beta", QueryType::Union, 20).await;
+    index.delete_documents(vec![0, 1, 10]).await;
+
+    let topk = search(
+        &index,
+        "alpha beta",
+        QueryType::Union,
+        ResultType::TopkCount,
+        true,
+    )
+    .await;
+    let count = search(
+        &index,
+        "alpha beta",
+        QueryType::Union,
+        ResultType::Count,
+        true,
+    )
+    .await;
+    assert_eq!(topk.result_count_total, 17);
+    assert_eq!(topk.results.len(), 17);
+    assert_eq!(count.result_count_total, 17);
+    index.close().await;
+}


### PR DESCRIPTION
## Summary
Realtime (`include_uncommitted=true`) totals ignore deletes: single-term
`TopkCount` 9 / `Count` 7 (want 8); OR `Count` 20 / `TopkCount` 32
(want 17). Follow-up to #71 and #73 (same miscount class, single-term
and OR paths); this is the surviving instance on the realtime path.

## Root cause
`realtime_search.rs`: single-term tail fell back to raw `posting_count`
(`:1283`, dropping deletes/facets from `filtered`); `union_count_uncommitted`
never consulted `delete_hashset`; single-hit `union_scan` double-counted
filtered docs (callee and caller each added one).

## Fix
Widen the tail `filtered`, thread `block_id` into `union_count_uncommitted`
and skip deleted docids, count the single hit only when fully unfiltered.
NOT/facet in realtime `Count` left as TODO (no params; out of scope).

## Tests
- New `realtime_delete_consistency.rs`: 2/2 green (5 consecutive runs);
  both fail without the fix.
- `test.rs` 15/15, `delete_uncommitted` 4/4; clippy/fmt clean.
- Perf: 452us (wrong) -> 506us (correct), 40-query avg, debug.
