### PR TITLE
Fix union_count cross-block union count jitter

### DIFF
--- a/seekstorm/src/union.rs
+++ b/seekstorm/src/union.rs
@@ -816,18 +816,22 @@ pub(crate) async fn union_count<'a>(
 ) {
     query_list.sort_unstable_by(|a, b| b.p_docid_count.partial_cmp(&a.p_docid_count).unwrap());
 
-    let mut result_count_local =
-        query_list[0].blocks[query_list[0].p_block as usize].posting_count as u32 + 1;
+    let first_valid_idx = query_list.iter().position(|plo| !plo.end_flag).unwrap_or(0);
+    let mut result_count_local = query_list[first_valid_idx].blocks
+        [query_list[first_valid_idx].p_block as usize]
+        .posting_count as u32
+        + 1;
 
     let mut bitmap_0: [u8; 8192] = [0u8; 8192];
+    let mut first_valid = true;
 
-    for (i, plo) in query_list.iter_mut().enumerate() {
+    for plo in query_list.iter_mut() {
         if plo.end_flag {
             continue;
         }
 
         if plo.compression_type == CompressionType::Bitmap {
-            if i == 0 {
+            if first_valid {
                 block_copy(
                     plo.byte_array,
                     plo.compressed_doc_id_range,
@@ -835,6 +839,7 @@ pub(crate) async fn union_count<'a>(
                     0,
                     8192,
                 );
+                first_valid = false;
             } else {
                 for i in (0..8192).step_by(8) {
                     let x1 = read_u64(&bitmap_0, i);
@@ -844,7 +849,7 @@ pub(crate) async fn union_count<'a>(
                 }
             }
         } else if plo.compression_type == CompressionType::Array {
-            if i == 0 {
+            if first_valid {
                 for i in 0..plo.p_docid_count {
                     let docid =
                         read_u16(&plo.byte_array[plo.compressed_doc_id_range..], i * 2) as usize;
@@ -853,6 +858,7 @@ pub(crate) async fn union_count<'a>(
 
                     bitmap_0[byte_index] |= 1 << bit_index;
                 }
+                first_valid = false;
             } else {
                 for i in 0..plo.p_docid_count {
                     let docid =
@@ -869,7 +875,7 @@ pub(crate) async fn union_count<'a>(
         } else {
             let runs_count = read_u16(&plo.byte_array[plo.compressed_doc_id_range..], 0) as i32;
 
-            if i == 0 {
+            if first_valid {
                 for ii in (1..(runs_count << 1) + 1).step_by(2) {
                     let startdocid = read_u16(
                         &plo.byte_array[plo.compressed_doc_id_range..],
@@ -888,6 +894,7 @@ pub(crate) async fn union_count<'a>(
                         bitmap_0[byte_index] |= 1 << bit_index;
                     }
                 }
+                first_valid = false;
             } else {
                 for ii in (1..(runs_count << 1) + 1).step_by(2) {
                     let startdocid = read_u16(

--- a/seekstorm/tests/union_count_cross_block.rs
+++ b/seekstorm/tests/union_count_cross_block.rs
@@ -1,0 +1,164 @@
+//! Regression test: multi-term `Union` `Count`/`TopkCount` must be consistent
+//! across repeated queries when terms span multiple blocks.
+//!
+//! `union_count` sorted terms including end-flagged ones, so a wrong-block
+//! term could land at index 0 and corrupt the initial count and bitmap.
+
+use seekstorm::commit::Commit;
+use seekstorm::index::{
+    AccessType, Close, Clustering, DocumentCompression, FrequentwordType, IndexDocuments,
+    IndexMetaObject, LexicalSimilarity, NgramSet, StemmerType, StopwordType, TokenizerType,
+    create_index,
+};
+use seekstorm::search::{QueryRewriting, QueryType, ResultType, Search, SearchMode};
+use seekstorm::vector::Inference;
+use std::{fs, path::Path};
+
+fn meta() -> IndexMetaObject {
+    IndexMetaObject {
+        id: 0,
+        name: "union_count_cross_block".into(),
+        lexical_similarity: LexicalSimilarity::Bm25f,
+        tokenizer: TokenizerType::UnicodeAlphanumeric,
+        stemmer: StemmerType::None,
+        stop_words: StopwordType::None,
+        frequent_words: FrequentwordType::None,
+        ngram_indexing: NgramSet::SingleTerm as u8,
+        document_compression: DocumentCompression::Snappy,
+        access_type: AccessType::Mmap,
+        spelling_correction: None,
+        query_completion: None,
+        clustering: Clustering::None,
+        inference: Inference::None,
+    }
+}
+
+fn schema() -> Vec<seekstorm::index::SchemaField> {
+    serde_json::from_str(
+        r#"[{"field":"title","field_type":"Text","store":true,"index_lexical":true}]"#,
+    )
+    .unwrap()
+}
+
+fn doc(title: &str) -> seekstorm::index::Document {
+    serde_json::from_str(&format!(r#"{{"title":"{title}"}}"#)).unwrap()
+}
+
+async fn search(
+    index: &seekstorm::index::IndexArc,
+    query: &str,
+    result_type: ResultType,
+) -> seekstorm::search::ResultObject {
+    index
+        .search(
+            query.into(),
+            None,
+            QueryType::Union,
+            SearchMode::Lexical,
+            false,
+            0,
+            100,
+            result_type,
+            false,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            QueryRewriting::SearchOnly,
+        )
+        .await
+}
+
+async fn fresh(dir: &str) -> seekstorm::index::IndexArc {
+    let path = Path::new(dir);
+    let _ = fs::remove_dir_all(path);
+    // Single shard so terms span multiple blocks (with default sharding each
+    // shard holds a single block and the bug is unreachable).
+    create_index(path, meta(), &schema(), &Vec::new(), 11, true, Some(1))
+        .await
+        .unwrap()
+}
+
+/// 3-term union across multiple blocks must return consistent results.
+///
+/// Sizes are asymmetric on purpose: the end-flagged term in block 1 (alpha,
+/// 60k) outranks the valid terms (beta/gamma, 5k each), so without the fix
+/// the sort deterministically puts it first and the count is wrong.
+#[tokio::test]
+async fn union_count_cross_block_consistent() {
+    let index = fresh("tests/index_union_cross_block/").await;
+    let mut docs = vec![];
+
+    // block 0: alpha (docid 0..60000)
+    for i in 0..60000 {
+        docs.push(doc(&format!("alpha item{i}")));
+    }
+    // padding crossing the 65536 block boundary
+    for i in 0..6000 {
+        docs.push(doc(&format!("padding filler{i}")));
+    }
+    // block 1: beta (docid 66000..71000)
+    for i in 0..5000 {
+        docs.push(doc(&format!("beta item{i}")));
+    }
+    // block 1: gamma (docid 71000..76000)
+    for i in 0..5000 {
+        docs.push(doc(&format!("gamma item{i}")));
+    }
+
+    index.index_documents(docs).await;
+    index.commit().await;
+
+    // 60k alpha + 5k beta + 5k gamma = 70_000; padding must not match.
+    let mut prev_count = 0;
+    for rep in 0..20 {
+        let count = search(&index, "alpha beta gamma", ResultType::Count).await;
+        let topk_count = search(&index, "alpha beta gamma", ResultType::TopkCount).await;
+
+        assert_eq!(
+            count.result_count_total, 70_000,
+            "Count absolute value mismatch at rep {rep}: expected 70_000, got {}",
+            count.result_count_total
+        );
+        if rep == 0 {
+            prev_count = count.result_count_total;
+        } else {
+            assert_eq!(
+                count.result_count_total, prev_count,
+                "Count jitter at rep {rep}: {prev_count} vs {}",
+                count.result_count_total
+            );
+        }
+        assert_eq!(
+            count.result_count_total, topk_count.result_count_total,
+            "Count and TopkCount mismatch at rep {rep}"
+        );
+    }
+
+    index.close().await;
+}
+
+/// Control: 2-term union (no cross-block issue) must be stable.
+#[tokio::test]
+async fn union_count_two_terms_stable() {
+    let index = fresh("tests/index_union_two_terms/").await;
+    let mut docs = vec![];
+
+    for i in 0..10 {
+        docs.push(doc(&format!("alpha uniq{i}")));
+    }
+    for i in 0..10 {
+        docs.push(doc(&format!("beta uniq{i}")));
+    }
+
+    index.index_documents(docs).await;
+    index.commit().await;
+
+    let count = search(&index, "alpha beta", ResultType::Count).await;
+    let topk_count = search(&index, "alpha beta", ResultType::TopkCount).await;
+
+    assert_eq!(count.result_count_total, 20);
+    assert_eq!(topk_count.result_count_total, 20);
+
+    index.close().await;
+}


### PR DESCRIPTION
## Summary

Multi-term Union `Count` returns inconsistent results across repeated
queries within the same process: the count oscillates between the
correct value and correct-plus-one-term (e.g. 180000 vs 240000, the
difference being exactly one full term's posting count). Independent
bug on the OR path, unrelated to deletions.

## Root cause

`union_count` (`union.rs:817`) sorts `query_list` by `p_docid_count`
descending, but the sorted list includes terms with `end_flag=true`
(terms not present in the current block). The sort may place an
end-flagged term at index 0, causing two issues:

1. `result_count_local` is initialized from the wrong block's
   `posting_count` (the end-flagged term's `p_block` points to a
   different block);
2. bitmap initialization uses an `i == 0` check, so when index 0 is
   skipped via `end_flag`, the first valid term is wrongly treated
   as a subsequent term.

Whether the end-flagged term lands first depends on pre-sort order,
which varies per query, hence the jitter.

## Fix

Use `first_valid_idx` (first term with `end_flag=false`) for count
initialization, and replace the three `i == 0` checks
(Bitmap/Array/Rle) with a `first_valid` flag so the bitmap is always
initialized from the correct term. The sort itself is kept.

## Tests

- New `seekstorm/tests/union_count_cross_block.rs` (2/2 green):
  single-shard 76k docs (alpha 60k in block 0, beta/gamma 5k each in
  block 1), 20 consecutive queries asserting absolute `Count == 70000`
  and `Count == TopkCount`. Verified it fails without the fix
  (130000 vs expected 70000 — exactly one extra term).
- `cargo fmt --check` clean for both touched files; `cargo clippy`
  reports no new warnings.

## Performance

No regression from this PR. We also evaluated removing the sort
entirely as an alternative; all three variants perform equivalently
(differences within noise), so this PR keeps the sort to stay minimal
and preserve the original optimization intent. Numbers below are debug
build, 20 reps per cell (relative values, 12 scales from 10 to 1M docs,
covering the 65536/131072 block boundaries with no cliff):

| Doc Count | Count (main) | Count (this PR) | Count (sort removed) | TopkCount (main) | TopkCount (this PR) | TopkCount (sort removed) |
|-----------|--------------|-----------------|----------------------|------------------|---------------------|--------------------------|
| 10        | 0.00ms       | 0.00ms          | 0.00ms               | 0.20ms           | 0.15ms              | 0.10ms                   |
| 100       | 0.00ms       | 0.00ms          | 0.00ms               | 0.45ms           | 0.50ms              | 0.40ms                   |
| 1,000     | 0.05ms       | 0.05ms          | 0.05ms               | 0.20ms           | 0.20ms              | 0.20ms                   |
| 10,000    | 0.30ms       | 0.25ms          | 0.20ms               | 1.20ms           | 1.20ms              | 1.10ms                   |
| 50,000    | 1.40ms       | 1.35ms          | 1.35ms               | 21.20ms          | 17.50ms             | 18.65ms                  |
| 65,536    | 2.05ms       | 1.75ms          | 1.90ms               | 27.45ms          | 24.45ms             | 28.15ms                  |
| 65,537    | 1.70ms       | 1.95ms          | 1.85ms               | 23.45ms          | 23.70ms             | 27.80ms                  |
| 100,000   | 2.30ms       | 2.80ms          | 3.25ms               | 35.55ms          | 35.80ms             | 46.95ms                  |
| 131,072   | 3.45ms       | 3.40ms          | 3.90ms               | 51.25ms          | 46.15ms             | 52.15ms                  |
| 180,000   | 4.80ms       | 4.65ms          | 5.05ms               | 67.15ms          | 62.45ms             | 72.30ms                  |
| 500,000   | 13.55ms      | 13.45ms         | 11.70ms              | 183.30ms         | 162.60ms            | 167.65ms                 |
| 1,000,000 | 26.95ms      | 26.20ms         | 23.60ms              | 361.50ms         | 319.75ms            | 310.25ms                 |

Geometric mean across the 12 scales — Count: 0.98ms (main) /
0.95ms (this PR) / 0.96ms (sort removed); TopkCount: 8.21ms /
7.68ms / 8.09ms. No consistent winner per scale; the fix is justified
by correctness, not performance.
