### PR TITLE
Fix range facet query panic on empty/uncovered ranges

### DIFF
--- a/seekstorm/src/add_result.rs
+++ b/seekstorm/src/add_result.rs
@@ -497,7 +497,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                         shard.facets_file_mmap[(shard.facets_size_sum * docid) + facet.offset];
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::U16(_range_type, ranges) => {
@@ -507,7 +507,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::U32(_range_type, ranges) => {
@@ -517,7 +517,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::U64(_range_type, ranges) => {
@@ -527,7 +527,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::I8(_range_type, ranges) => {
@@ -537,7 +537,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::I16(_range_type, ranges) => {
@@ -547,7 +547,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::I32(_range_type, ranges) => {
@@ -557,7 +557,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
 
@@ -568,7 +568,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::Timestamp(_range_type, ranges) => {
@@ -578,7 +578,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by_key(&facet_value, |range| range.1)
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::F32(_range_type, ranges) => {
@@ -588,7 +588,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by(|range| range.1.partial_cmp(&facet_value).unwrap())
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
                 Ranges::F64(_range_type, ranges) => {
@@ -598,7 +598,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                     );
                     ranges
                         .binary_search_by(|range| range.1.partial_cmp(&facet_value).unwrap())
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
 
@@ -613,7 +613,7 @@ pub(crate) fn facet_count(shard: &Shard, search_result: &mut SearchResult, docid
                         .binary_search_by(|range| {
                             range.1.partial_cmp(&facet_value_distance).unwrap()
                         })
-                        .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                        .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                         as u32
                 }
 

--- a/seekstorm/src/search.rs
+++ b/seekstorm/src/search.rs
@@ -2741,6 +2741,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::U8
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2758,6 +2759,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::U16
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2775,6 +2777,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::U32
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2792,6 +2795,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::U64
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2809,6 +2813,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::I8
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2826,6 +2831,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::I16
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2843,6 +2849,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::I32
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2860,6 +2867,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::I64
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2877,6 +2885,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::Timestamp
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2894,6 +2903,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::F32
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2911,6 +2921,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::F64
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {
@@ -2996,6 +3007,7 @@ impl SearchLexicalShard for ShardArc {
                     } => {
                         if let Some(idx) = shard_ref.facets_map.get(field)
                             && shard_ref.facets[*idx].field_type == FieldType::Point
+                            && !ranges.is_empty()
                         {
                             is_range_facet = true;
                             search_result.query_facets[*idx] = ResultFacet {

--- a/seekstorm/src/union.rs
+++ b/seekstorm/src/union.rs
@@ -1019,7 +1019,7 @@ pub(crate) async fn union_count<'a>(
                                 [(shard.facets_size_sum * docid) + facet.offset];
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::U16(_range_type, ranges) => {
@@ -1029,7 +1029,7 @@ pub(crate) async fn union_count<'a>(
                             );
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::U32(_range_type, ranges) => {
@@ -1039,7 +1039,7 @@ pub(crate) async fn union_count<'a>(
                             );
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::U64(_range_type, ranges) => {
@@ -1049,7 +1049,7 @@ pub(crate) async fn union_count<'a>(
                             );
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::I8(_range_type, ranges) => {
@@ -1059,7 +1059,7 @@ pub(crate) async fn union_count<'a>(
                             );
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::I16(_range_type, ranges) => {
@@ -1069,7 +1069,7 @@ pub(crate) async fn union_count<'a>(
                             );
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::I32(_range_type, ranges) => {
@@ -1079,7 +1079,7 @@ pub(crate) async fn union_count<'a>(
                             );
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::I64(_range_type, ranges) => {
@@ -1089,7 +1089,7 @@ pub(crate) async fn union_count<'a>(
                             );
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::Timestamp(_range_type, ranges) => {
@@ -1099,7 +1099,7 @@ pub(crate) async fn union_count<'a>(
                             );
                             ranges
                                 .binary_search_by_key(&facet_value, |range| range.1)
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::F32(_range_type, ranges) => {
@@ -1111,7 +1111,7 @@ pub(crate) async fn union_count<'a>(
                                 .binary_search_by(|range| {
                                     range.1.partial_cmp(&facet_value).unwrap()
                                 })
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::F64(_range_type, ranges) => {
@@ -1123,7 +1123,7 @@ pub(crate) async fn union_count<'a>(
                                 .binary_search_by(|range| {
                                     range.1.partial_cmp(&facet_value).unwrap()
                                 })
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
                         Ranges::Point(_range_type, ranges, base, unit) => {
@@ -1137,7 +1137,7 @@ pub(crate) async fn union_count<'a>(
                                 .binary_search_by(|range| {
                                     range.1.partial_cmp(&facet_value_distance).unwrap()
                                 })
-                                .map_or_else(|idx| idx as u16 - 1, |idx| idx as u16)
+                                .map_or_else(|idx| idx.saturating_sub(1) as u16, |idx| idx as u16)
                                 as u32
                         }
 

--- a/seekstorm/tests/facet_empty_ranges.rs
+++ b/seekstorm/tests/facet_empty_ranges.rs
@@ -1,0 +1,109 @@
+//! Repro: numeric range QueryFacet with empty `ranges` must not panic the search.
+//! Public API only: create_index / index_document(s) / commit / search.
+//! Run: cargo test -p seekstorm --test facet_empty_ranges
+
+use seekstorm::commit::Commit;
+use seekstorm::index::{
+    AccessType, Close, Clustering, Document, DocumentCompression, FileType, FrequentwordType,
+    IndexDocument, IndexMetaObject, LexicalSimilarity, NgramSet, StemmerType, StopwordType,
+    TokenizerType, create_index,
+};
+use seekstorm::search::{
+    QueryFacet, QueryRewriting, QueryType, RangeType, ResultType, Search, SearchMode,
+};
+use seekstorm::vector::Inference;
+use std::{fs, path::Path};
+
+#[tokio::test]
+async fn repro_range_facet_empty_ranges_no_panic() {
+    let index_path = Path::new("/tmp/repro_facet_empty_ranges/");
+    let _ = fs::remove_dir_all(index_path);
+
+    let schema_json = r#"
+    [{"field":"title","field_type":"Text","store":true,"index_lexical":true,"longest":true},
+    {"field":"age","field_type":"U8","store":true,"index_lexical":false,"facet":true}]"#;
+    let schema = serde_json::from_str(schema_json).unwrap();
+    let meta = IndexMetaObject {
+        id: 0,
+        name: "repro_facet".into(),
+        lexical_similarity: LexicalSimilarity::Bm25f,
+        tokenizer: TokenizerType::UnicodeAlphanumeric,
+        stemmer: StemmerType::None,
+        stop_words: StopwordType::None,
+        frequent_words: FrequentwordType::None,
+        ngram_indexing: NgramSet::SingleTerm as u8,
+        document_compression: DocumentCompression::Snappy,
+        access_type: AccessType::Mmap,
+        spelling_correction: None,
+        query_completion: None,
+        clustering: Clustering::None,
+        inference: Inference::None,
+    };
+    let index_arc = create_index(index_path, meta, &schema, &Vec::new(), 11, false, None)
+        .await
+        .unwrap();
+
+    let documents_json = r#"
+    [{"title":"hello world","age":25},
+    {"title":"hello there","age":30}]"#;
+    let documents_vec: Vec<Document> = serde_json::from_str(documents_json).unwrap();
+    for document in documents_vec {
+        index_arc.index_document(document, FileType::None).await;
+    }
+    // commit() drains in-flight index tasks via the shard semaphore.
+    index_arc.commit().await;
+
+    // Sanity without facets: both docs match.
+    let rlo = index_arc
+        .search(
+            "hello".into(),
+            None,
+            QueryType::Union,
+            SearchMode::Lexical,
+            false,
+            0,
+            10,
+            ResultType::Count,
+            false,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            QueryRewriting::SearchOnly,
+        )
+        .await;
+    assert_eq!(rlo.result_count_total, 2, "setup: Count without facets");
+
+    // Same query + numeric range facet with EMPTY ranges: must not panic.
+    // Pre-fix: `idx as u16 - 1` on Err(0) underflows in facet_count/union_count.
+    let query_facets = vec![QueryFacet::U8 {
+        field: "age".into(),
+        range_type: RangeType::CountWithinRange,
+        ranges: Vec::new(),
+    }];
+    let rlo = index_arc
+        .search(
+            "hello".into(),
+            None,
+            QueryType::Union,
+            SearchMode::Lexical,
+            false,
+            0,
+            10,
+            ResultType::Count,
+            false,
+            Vec::new(),
+            query_facets,
+            Vec::new(),
+            Vec::new(),
+            QueryRewriting::SearchOnly,
+        )
+        .await;
+    assert_eq!(
+        rlo.result_count_total, 2,
+        "Count with empty-ranges facet must still count matches"
+    );
+
+    index_arc.close().await;
+    let _ = fs::remove_dir_all(index_path);
+}


### PR DESCRIPTION
## Summary

A numeric range `QueryFacet` with empty `ranges` panics any search with a matching document in debug builds — deterministic, via plain public API: `attempt to subtract with overflow` at `add_result.rs:500`, re-panicked at the merge (`search.rs:1880`), so one bad query panics twice. Release builds (`overflow-checks=false`) do not crash: the underflow wraps to bucket 65535, which the 3.3.8 render hardening drops via `.get()` — but the facet breakdown is then silently lost while counts stay correct, so behavior differs across profiles for the same query. The same expression also fires for values below the first range start (e.g. an `I8` document value below `ranges[0].1`): 24 sites across all numeric types (`facet_count` x12 in `add_result.rs`, `union_count` x12 in `union.rs`). Not covered by #66-#76 (facet-only #69 was a scoping defect, different root cause).

Minimal repro (default features):

```rust
// schema: title Text indexed; age U8 facet:true. Docs: {"title":"hello world","age":25}, ...
index_arc.commit().await;
let query_facets = vec![QueryFacet::U8 {
    field: "age".into(), range_type: RangeType::CountWithinRange, ranges: Vec::new(),
}];
index_arc.search("hello".into(), None, QueryType::Union, SearchMode::Lexical,
    false, 0, 10, ResultType::Count, false,
    Vec::new(), query_facets, Vec::new(), Vec::new(),
    QueryRewriting::SearchOnly).await;
// pre-fix (debug): panics at add_result.rs:500, then search.rs:1880
```

## Root cause

`search.rs` clones user-supplied `ranges` verbatim with `length = u16::MAX` (so the `length == 0` guard never skips them); no empty/coverage validation exists anywhere. `ranges.binary_search_by_key(...)` returns `Err(0)` and `idx as u16 - 1` underflows.

## Fix

Two levels, either alone is insufficient (saturating alone still OOBs at render `ranges[0]` for empty ranges; intake alone leaves below-first-start values panicking in debug):

- Intake (`search.rs`, 12 numeric arms): `&& !ranges.is_empty()` — empty-ranges facets stay default (length 0), skipped everywhere, result counts untouched. This mirrors the existing intake behavior for unknown facet fields (silently ignored).
- Expression (`add_result.rs` x12, `union.rs` x12): `idx.saturating_sub(1) as u16` — uncovered-low values clamp to bucket 0 instead of panicking, symmetric with the existing above-last-bound clamp (`Err(len)` -> last bucket). Bit-identical for all previously-valid inputs (only `idx == 0` changes, which previously never produced output: debug panicked, release dropped the bucket at render).

## Tests

- New `seekstorm/tests/facet_empty_ranges.rs`: panics without the fix (exact sites above), green with it.
- Full suite green: `test.rs` 15/15, all `*_consistency` suites, 91 doc-tests; `cargo clippy` reports no new warnings (5 pre-existing in untouched vector files); `cargo fmt --check` clean on touched files.

## Performance

No hot-path change by construction (no benchmark table: there is no algorithmic change to measure — unlike #71, no fast path is removed): one `len` check per range facet at query setup; `saturating_sub` replaces the panicking `sub` at identical cost on the non-underflowing path. Valid queries take identical branches pre/post fix.

Out of scope: unsorted range starts (violates the documented ascending convention); separate follow-up if needed.
