### PR TITLE
Fix server abort on non-UTF8 request bodies

### DIFF
--- a/seekstorm_server/src/http_server.rs
+++ b/seekstorm_server/src/http_server.rs
@@ -108,6 +108,7 @@ enum HttpServerError {
     SynonymsNotFound,
     Unauthorized,
     BadRequest(String),
+    InternalServerError,
     NotImplemented,
     FileNotFound,
     DocumentNotFound,
@@ -133,6 +134,10 @@ impl From<HttpServerError> for Result<Response<BoxBody<Bytes, Infallible>>, Infa
             HttpServerError::BadRequest(error_message) => status(
                 StatusCode::BAD_REQUEST,
                 format!("bad request:{}", error_message),
+            ),
+            HttpServerError::InternalServerError => status(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal server error".to_string(),
             ),
             HttpServerError::NotImplemented => {
                 status(StatusCode::NOT_IMPLEMENTED, "not implemented".to_string())
@@ -612,7 +617,11 @@ pub(crate) async fn http_request_handler(
                 INDEX_RUNTIME.block_on(async move { commit_index_api(&index_arc_clone).await })
             });
 
-            match task_result.join().unwrap() {
+            let join_result = match task_result.join() {
+                Ok(join_result) => join_result,
+                Err(_) => return HttpServerError::InternalServerError.into(),
+            };
+            match join_result {
                 Ok(status_object_json) => Ok(Response::new(BoxBody::new(Full::new(
                     status_object_json.to_string().into(),
                 )))),
@@ -917,7 +926,11 @@ pub(crate) async fn http_request_handler(
 
             let task_result = std::thread::spawn(move || {
                 INDEX_RUNTIME.block_on(async move {
-                    let request_string = str::from_utf8(&request_bytes).unwrap();
+                    let Ok(request_string) = str::from_utf8(&request_bytes) else {
+                        return serde_json::to_vec(&Err::<usize, String>(
+                            "request body is not valid UTF-8".to_string(),
+                        ));
+                    };
 
                     let status_object = if !request_string.trim().starts_with('[') {
                         let document_object = serde_json::from_str(request_string)?;
@@ -930,7 +943,11 @@ pub(crate) async fn http_request_handler(
                 })
             });
 
-            match task_result.join().unwrap() {
+            let join_result = match task_result.join() {
+                Ok(join_result) => join_result,
+                Err(_) => return HttpServerError::InternalServerError.into(),
+            };
+            match join_result {
                 Ok(status_object_json) => Ok(Response::new(BoxBody::new(Full::new(
                     status_object_json.into(),
                 )))),
@@ -955,7 +972,11 @@ pub(crate) async fn http_request_handler(
                     .into();
             };
             let request_bytes = req.into_body().collect().await.unwrap().to_bytes();
-            let request_string = str::from_utf8(&request_bytes).unwrap().trim();
+            let Ok(request_string) = str::from_utf8(&request_bytes) else {
+                return HttpServerError::BadRequest("request body is not valid UTF-8".to_string())
+                    .into();
+            };
+            let request_string = request_string.trim();
 
             let apikey_list_ref = apikey_list.read().await;
             let Some(apikey_object) = apikey_list_ref.get(&apikey_hash) else {
@@ -1165,7 +1186,12 @@ pub(crate) async fn http_request_handler(
                                 ))))
                             }
                             Err(_) => {
-                                let request_string = str::from_utf8(&request_bytes).unwrap();
+                                let Ok(request_string) = str::from_utf8(&request_bytes) else {
+                                    return HttpServerError::BadRequest(
+                                        "request body is not valid UTF-8".to_string(),
+                                    )
+                                    .into();
+                                };
                                 let is_doc_vector = request_string.trim().starts_with('[');
                                 let status_object = if !is_doc_vector {
                                     let document_id = match serde_json::from_str(request_string) {


### PR DESCRIPTION
## Summary

Release builds set `panic = "abort"` (workspace profile; production Dockerfile builds `--release`), so any request-handler panic kills the whole multi-tenant server process. Three endpoints called `str::from_utf8().unwrap()` on client-supplied bodies after auth (index POST/PATCH, delete-by-query): any tenant sending non-UTF8 bytes aborts the server for all tenants with a single request — rate limiting cannot help, and in-flight commits are torn with it. Debug evidence from a live server: `http_server.rs:920:73 Utf8Error` followed by `933:38 JoinError` (the task join re-panics on the dead worker); abort semantics verified with an identical spawn/unwrap construct under `panic = "abort"` (exit code 134). A valid apikey is required (not anonymous): multi-tenant this is a tenant-isolation break; single-tenant it is robustness-only.

Live repro (debug server; release aborts instead of dropping the connection):

```bash
# non-UTF8 body to index-document endpoint
printf '{"title":"\xff\xfe broken"}' > bad.bin
curl -X POST /api/v1/index/0/doc -H "apikey: $KEY" --data-binary @bad.bin
# pre-fix: connection dies, server log shows 920:73 then 933:38
```

## Root cause

Missing UTF-8 validation between auth and serde: malformed JSON is handled gracefully (`BadRequest`) on every neighboring path, but non-UTF-8 bytes die in `from_utf8().unwrap()` before serde is ever reached (3 sites). The `task_result.join().unwrap()` then re-panics on the dead worker (2 sites: index POST, commit).

## Fix

Graceful errors instead of panics, mirroring neighboring conventions: `BadRequest` for the three UTF-8 sites (index POST keeps that endpoint's 200-with-`Result` body convention), and a new `InternalServerError` (500) variant for a dead worker — no honest 5xx existed, and reusing `BadRequest` would misattribute a server-side failure. Valid request paths are byte-identical (only `Err` branches added).

## Tests

Live server, three attacks + control, pre/post fix: non-UTF8 POST/PATCH/DELETE bodies panicked pre-fix (`920:73`, `933:38`), return graceful errors post-fix with zero panics in the log; a valid document still indexes (`{"Ok":0}`); server alive throughout. `cargo check/clippy/fmt` clean on the touched file. (The server crate has no unit tests; the `seekstorm` lib suite is untouched by this change.)

## Performance

Error branches only; the hot path adds zero instructions. No benchmark table: nothing algorithmic changed.

Out of scope: PATCH slice-bounds panic on `[{` bodies; request body size limit (needs a product threshold); `collect()` transport-error unwraps — separate follow-ups.
