### PR TITLE
Fix get_document panic on doc following doc(s) with no stored fields

### DIFF
--- a/seekstorm/src/doc_store.rs
+++ b/seekstorm/src/doc_store.rs
@@ -65,11 +65,29 @@ impl Shard {
             let position = doc_id_local * 4;
             let pointer = read_u32(docstore_pointer_docs, position) as usize;
 
-            let previous_pointer = if doc_id == self.committed_doc_count || doc_id_local == 0 {
+            let mut previous_pointer = if doc_id == self.committed_doc_count || doc_id_local == 0 {
                 ROARING_BLOCK_SIZE * 4
             } else {
                 read_u32(docstore_pointer_docs, position - 4) as usize
             };
+
+            if previous_pointer < ROARING_BLOCK_SIZE * 4 {
+                // Predecessor slot(s) unwritten: documents without stored
+                // fields write no pointer, leaving stale zeros. Walk back to
+                // the nearest written slot (doc data always starts after the
+                // pointer table), so a valid doc after empty one(s) reads
+                // exactly its own bytes instead of slicing from 0 and
+                // panicking below.
+                previous_pointer = ROARING_BLOCK_SIZE * 4;
+                let mut back = position;
+                while back > 0 {
+                    back -= 4;
+                    let slot = read_u32(docstore_pointer_docs, back) as usize;
+                    if slot > previous_pointer {
+                        previous_pointer = slot;
+                    }
+                }
+            }
 
             if previous_pointer >= pointer || pointer > docstore_pointer_docs.len() {
                 // Equal means an empty slot (e.g. a document with no stored
@@ -111,19 +129,28 @@ impl Shard {
             let position =
                 self.level_index[level].docstore_pointer_docs_pointer + (doc_id_local * 4);
 
-            let (previous_pointer, pointer) = if doc_id_local == 0 {
-                (
-                    ROARING_BLOCK_SIZE * 4,
-                    read_u32(&self.docstore_file_mmap, position) as usize,
-                )
+            let table_base = self.level_index[level].docstore_pointer_docs_pointer;
+            let pointer = read_u32(&self.docstore_file_mmap, position) as usize;
+            let mut previous_pointer = if doc_id_local == 0 {
+                ROARING_BLOCK_SIZE * 4
             } else {
-                (
-                    read_u32(&self.docstore_file_mmap, position - 4) as usize,
-                    read_u32(&self.docstore_file_mmap, position) as usize,
-                )
+                read_u32(&self.docstore_file_mmap, position - 4) as usize
             };
 
-            let table_base = self.level_index[level].docstore_pointer_docs_pointer;
+            if previous_pointer < ROARING_BLOCK_SIZE * 4 {
+                // Same stale-zero predecessor slots as in the RAM branch
+                // above: walk back within this block's table.
+                previous_pointer = ROARING_BLOCK_SIZE * 4;
+                let mut back = position;
+                while back > table_base {
+                    back -= 4;
+                    let slot = read_u32(&self.docstore_file_mmap, back) as usize;
+                    if slot > previous_pointer {
+                        previous_pointer = slot;
+                    }
+                }
+            }
+
             let start = table_base.saturating_add(previous_pointer);
             let end = table_base.saturating_add(pointer);
             if previous_pointer >= pointer || end > self.docstore_file_mmap.len() {

--- a/seekstorm/tests/get_successor_doc.rs
+++ b/seekstorm/tests/get_successor_doc.rs
@@ -1,0 +1,117 @@
+//! Repro: get_document on a valid doc following doc(s) with no stored fields.
+//! Stale-zero predecessor slots made it slice from 0 and panic.
+//! Matrix: Ram/Mmap x None/Snappy. Public API only.
+use seekstorm::commit::Commit;
+use seekstorm::index::{
+    AccessType, Close, Clustering, Document, DocumentCompression, FileType, FrequentwordType,
+    IndexDocument, IndexMetaObject, LexicalSimilarity, NgramSet, StemmerType, StopwordType,
+    TokenizerType, create_index,
+};
+use seekstorm::vector::Inference;
+use std::{collections::HashSet, fs, path::Path};
+
+use futures::FutureExt;
+
+async fn run_case(access: AccessType, compression: DocumentCompression, tag: &str) {
+    let dir = format!("/tmp/repro_succ_{tag}/");
+    let index_path = Path::new(&dir);
+    let _ = fs::remove_dir_all(index_path);
+    let schema_json = r#"
+    [{"field":"title","field_type":"Text","store":true,"index_lexical":true,"longest":true},
+    {"field":"tag","field_type":"Text","store":false,"index_lexical":true}]"#;
+    let schema = serde_json::from_str(schema_json).unwrap();
+    let meta = IndexMetaObject {
+        id: 0,
+        name: "succ".into(),
+        lexical_similarity: LexicalSimilarity::Bm25f,
+        tokenizer: TokenizerType::UnicodeAlphanumeric,
+        stemmer: StemmerType::None,
+        stop_words: StopwordType::None,
+        frequent_words: FrequentwordType::None,
+        ngram_indexing: NgramSet::SingleTerm as u8,
+        document_compression: compression,
+        access_type: access,
+        spelling_correction: None,
+        query_completion: None,
+        clustering: Clustering::None,
+        inference: Inference::None,
+    };
+    let index_arc = create_index(index_path, meta, &schema, &Vec::new(), 11, false, Some(1))
+        .await
+        .unwrap();
+    // doc 0: indexed-only field -> no stored content -> slot stays 0.
+    // doc 1: another empty one (run of empties).
+    // doc 2: stored content right after the empty run.
+    // doc 3: stored baseline (real predecessor).
+    // doc 4: empty again; doc 5: stored content after a MIXED run
+    //   (real, empty, real) -> exercises the backward scan beyond what a
+    //   simple clamp-to-table would fix.
+    for json in [
+        r#"{"tag":"hello"}"#,
+        r#"{"tag":"world"}"#,
+        r#"{"title":"hello world"}"#,
+        r#"{"title":"baseline doc"}"#,
+        r#"{"tag":"again"}"#,
+        r#"{"title":"mixed successor"}"#,
+    ] {
+        let doc: Document = serde_json::from_str(json).unwrap();
+        index_arc.index_document(doc, FileType::None).await;
+    }
+    index_arc.commit().await;
+
+    let index = index_arc.read().await;
+    // Empty docs themselves stay not-found (documented behavior, cf. #72).
+    assert!(
+        index
+            .get_document(0, false, &None, &HashSet::new(), &Vec::new())
+            .await
+            .is_err()
+    );
+    assert!(
+        index
+            .get_document(1, false, &None, &HashSet::new(), &Vec::new())
+            .await
+            .is_err()
+    );
+    // The valid successors must come back with EXACT content, not panic.
+    for (id, want) in [
+        (2, "hello world"),
+        (3, "baseline doc"),
+        (5, "mixed successor"),
+    ] {
+        let doc = index
+            .get_document(id, false, &None, &HashSet::new(), &Vec::new())
+            .await
+            .unwrap_or_else(|e| panic!("BUG [{tag}]: valid doc {id} unreadable: {e}"));
+        let title: String = serde_json::from_value(doc.get("title").unwrap().clone()).unwrap();
+        assert_eq!(title, want, "BUG [{tag}]: wrong content for doc {id}");
+    }
+    drop(index);
+    index_arc.close().await;
+    let _ = fs::remove_dir_all(index_path);
+    println!("CASE {tag}: ok");
+}
+
+#[tokio::test]
+async fn successor_after_empty_matrix() {
+    let mut fails = 0;
+    for (access, compression, tag) in [
+        (AccessType::Ram, DocumentCompression::None, "ram-none"),
+        (AccessType::Ram, DocumentCompression::Snappy, "ram-snappy"),
+        (AccessType::Mmap, DocumentCompression::None, "mmap-none"),
+        (AccessType::Mmap, DocumentCompression::Snappy, "mmap-snappy"),
+    ] {
+        // per-case panic isolation: one panicking combo must not hide the rest
+        let r = std::panic::AssertUnwindSafe(run_case(access, compression, tag))
+            .catch_unwind()
+            .await;
+        match r {
+            Ok(()) => {}
+            Err(_) => {
+                fails += 1;
+                println!("CASE {tag}: PANIC");
+            }
+        }
+    }
+    assert_eq!(fails, 0, "BUG: {fails} combos panic/unreadable");
+}


### PR DESCRIPTION
## Summary

`get_document` on a valid doc whose predecessor slot(s) are unwritten panics — Ram + Mmap, all codecs. Deterministic, 2-3 docs, public API only. Follow-up to #72 (which fixed reading the empty doc itself; this is the **valid successor**): docs without stored fields write no docstore pointer, leaving stale zeros; the successor read uses the predecessor slot as its slice start, slicing from 0 and panicking in decompress/`from_slice`. Verified pre-fix panics: Ram/None `doc_store.rs:86`, Ram/Snappy `:92`, Mmap/None `:141`, Mmap/Snappy `:147`.

Minimal repro: schema with a stored and an indexed-only field; index `{"tag":"hello"}` (empty slot), then `{"title":"hello world"}`; `commit()`; `get_document(1, ...)` panics.

## Root cause

`store_document` (`doc_store.rs:240`) returns early for field-less docs without writing a pointer. The successor's `previous_pointer` then reads stale `0`, which passes both existing guards (`0 < pointer`, `pointer == len`) and slices `[0..pointer]` (whole table + data) into `unwrap()`. #72's guard only catches `previous >= pointer` (the empty doc itself).

## Fix

Walk back to the nearest written slot when `previous_pointer` is below the table size (doc data always starts after the pointer table) — in both the Ram and Mmap branches. Returns exactly the doc's own bytes; empty-slot (`Err`) and corrupt-offset guards unchanged. Normal reads (written predecessor) take one extra comparison, zero behavior change.

## Tests

- New `seekstorm/tests/get_successor_doc.rs`: Ram/Mmap x None/Snappy matrix plus a mixed (real, empty, real) run that a plain clamp-to-table would still get wrong — all four panic pre-fix at the exact lines above, all return exact content post-fix.
- Full suite green: `test.rs` 15/15, all `*_consistency` suites, 91 doc-tests; `cargo clippy` reports no new warnings; `cargo fmt --check` clean on touched files.

## Performance

The backward scan runs only when `previous_pointer` is below table size — a path that previously panicked unconditionally. Normal reads add a single comparison. No benchmark table: nothing on a hot path changed.

Out of scope: none.
