### PR TITLE
Write docstore pointer for empty docs (eliminate walk-back loop)

### DIFF
--- a/seekstorm/src/doc_store.rs
+++ b/seekstorm/src/doc_store.rs
@@ -65,29 +65,11 @@ impl Shard {
             let position = doc_id_local * 4;
             let pointer = read_u32(docstore_pointer_docs, position) as usize;
 
-            let mut previous_pointer = if doc_id == self.committed_doc_count || doc_id_local == 0 {
+            let previous_pointer = if doc_id == self.committed_doc_count || doc_id_local == 0 {
                 ROARING_BLOCK_SIZE * 4
             } else {
                 read_u32(docstore_pointer_docs, position - 4) as usize
             };
-
-            if previous_pointer < ROARING_BLOCK_SIZE * 4 {
-                // Predecessor slot(s) unwritten: documents without stored
-                // fields write no pointer, leaving stale zeros. Walk back to
-                // the nearest written slot (doc data always starts after the
-                // pointer table), so a valid doc after empty one(s) reads
-                // exactly its own bytes instead of slicing from 0 and
-                // panicking below.
-                previous_pointer = ROARING_BLOCK_SIZE * 4;
-                let mut back = position;
-                while back > 0 {
-                    back -= 4;
-                    let slot = read_u32(docstore_pointer_docs, back) as usize;
-                    if slot > previous_pointer {
-                        previous_pointer = slot;
-                    }
-                }
-            }
 
             if previous_pointer >= pointer || pointer > docstore_pointer_docs.len() {
                 // Equal means an empty slot (e.g. a document with no stored
@@ -131,25 +113,11 @@ impl Shard {
 
             let table_base = self.level_index[level].docstore_pointer_docs_pointer;
             let pointer = read_u32(&self.docstore_file_mmap, position) as usize;
-            let mut previous_pointer = if doc_id_local == 0 {
+            let previous_pointer = if doc_id_local == 0 {
                 ROARING_BLOCK_SIZE * 4
             } else {
                 read_u32(&self.docstore_file_mmap, position - 4) as usize
             };
-
-            if previous_pointer < ROARING_BLOCK_SIZE * 4 {
-                // Same stale-zero predecessor slots as in the RAM branch
-                // above: walk back within this block's table.
-                previous_pointer = ROARING_BLOCK_SIZE * 4;
-                let mut back = position;
-                while back > table_base {
-                    back -= 4;
-                    let slot = read_u32(&self.docstore_file_mmap, back) as usize;
-                    if slot > previous_pointer {
-                        previous_pointer = slot;
-                    }
-                }
-            }
 
             let start = table_base.saturating_add(previous_pointer);
             let end = table_base.saturating_add(pointer);
@@ -275,6 +243,11 @@ impl Shard {
         }
 
         if document.is_empty() {
+            write_u32(
+                self.compressed_docstore_segment_block_buffer.len() as u32,
+                &mut self.compressed_docstore_segment_block_buffer,
+                (doc_id & 0b11111111_11111111) * 4,
+            );
             return;
         }
 


### PR DESCRIPTION
Eliminate the O(ROARING_BLOCK_SIZE) walk-back loop from get_document (follow-up to #81, addressing wolfgarbe's review)

## Summary

Follow-up to #81 (merged). `get_document` on a valid doc whose predecessor slot(s) are unwritten currently walks back toward the start of the block to find the nearest written pointer (`previous_pointer < ROARING_BLOCK_SIZE * 4`). This is token-correct but leaves a worst-case O(ROARING_BLOCK_SIZE) latency envelope on single-document reads when that slot is never written. This PR replaces the read-side scan with a write-side invariant: every document writes a docstore pointer, so the table is always monotonic non-decreasing and `prev == cur` is the sole "empty document" signal.

## Root cause

`store_document` (`doc_store.rs`) returns early for documents with no stored fields without writing a pointer slot, leaving a stale zero. The read side must then special-case the case where a predecessor slot was never written, which is what the walk-back loop does.

## Fix

- `store_document`: empty documents now write the current end offset as a placeholder instead of returning without a slot. The pointer table becomes a monotonic running-end-offset log with no zero/unwritten state representable.
- `get_document_shard` (Ram + Mmap branches): the two `while` walk-back loops are deleted. Reads are back to a single pointer comparison; `prev == cur` (equal) is a zero-length record and hits the existing guard.
- Net diff on `doc_store.rs` vs `origin/main`: +7/-34. The 117-line test matrix from #81 (`get_successor_doc.rs`) is unchanged and keeps passing.

## Tests

- `seekstorm/tests/get_successor_doc.rs` (Ram/Mmap x None/Snappy plus the mixed real/empty/real run that a plain clamp-to-table would still get wrong): 4/4 pass, unchanged from #81.
- Full suite green: `test.rs` 15/15, all `*_consistency` suites, 91 doc-tests; `cargo clippy` no new warnings; `cargo fmt --check` clean on touched files.
- No dedicated test for the block boundary (`doc_id_local == 0`) placeholder path; it is covered by the existing first-doc branch and the `saturating_add` corrupt-offset guard.

## Performance

No benchmark table. The change is deletion of a loop plus a single placeholder write on a cold path (indexing documents with no stored fields); normal reads gain a comparison that was already there. No hot path introduced.
