### PR TITLE
Cut temp allocs in Shard::index_posting via SmallVec

### DIFF
--- a/seekstorm/src/index_posting.rs
+++ b/seekstorm/src/index_posting.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 
 use num::FromPrimitive;
+use smallvec::SmallVec;
 
 use crate::{
     compress_postinglist::compress_positions,
@@ -49,10 +50,10 @@ impl Shard {
         };
 
         let mut positions_count_sum = 0;
-        let mut field_positions_vec: Vec<Vec<u16>> = Vec::new();
+        let mut field_positions_vec: SmallVec<[SmallVec<[u16; 8]>; 2]> = SmallVec::new();
         for positions_uncompressed in term.field_positions_vec.iter() {
             positions_count_sum += positions_uncompressed.len();
-            let mut positions: Vec<u16> = Vec::new();
+            let mut positions: SmallVec<[u16; 8]> = SmallVec::new();
             let mut previous_position: u16 = 0;
             for pos in positions_uncompressed.iter() {
                 if positions.is_empty() {
@@ -396,8 +397,8 @@ impl Shard {
         }
 
         let mut positions_sum = 0;
-        let mut positions_vec: Vec<u16> = Vec::new();
-        let mut field_vec: Vec<(usize, u32)> = Vec::new();
+        let mut positions_vec: SmallVec<[u16; 8]> = SmallVec::new();
+        let mut field_vec: SmallVec<[(usize, u32); 2]> = SmallVec::new();
         for (field_id, field) in field_positions_vec.iter().enumerate() {
             if !field.is_empty() {
                 if field_positions_vec.len() == 1 {
@@ -435,7 +436,7 @@ impl Shard {
 
                 positions_sum += field.len();
                 if self.indexed_field_vec.len() > 1 && field.len() <= 4 {
-                    positions_vec.append(&mut field.clone())
+                    positions_vec.extend(field.iter().copied())
                 };
 
                 field_vec.push((field_id, field.len() as u32));
@@ -590,7 +591,7 @@ impl Shard {
         };
 
         let compressed_position_size = if embed_flag {
-            let mut positions_vec: Vec<u16> = Vec::new();
+            let mut positions_vec: SmallVec<[u16; 8]> = SmallVec::new();
             let mut data: u32 = 0;
             for field in field_vec.iter() {
                 for pos in field_positions_vec[field.0].iter() {


### PR DESCRIPTION
## Summary

`Shard::index_posting` heap-allocates ~4 transient Vecs per unique-term-per-doc, even though the common case (1-2 indexed fields, few occurrences) fits inline. This PR switches these short-lived buffers to `SmallVec`. Measured (release): allocations -13.1% at 1K/10K/100K docs (exactly -4.0 per term-doc at every scale), -40.4% on sparse text; allocated bytes -3%~-11%; wall-clock and peak RSS neutral. Related to #48 (allocation part only).

## Root cause

Per-term-per-doc temp buffers (`field_positions_vec` outer/inner, `field_vec`, `positions_vec`) allocate on first push unconditionally. They never escape the function — pure overhead.

## Fix

Container-only swap to `SmallVec` with small inline capacities, plus `append(&mut clone)` -> `extend(copied)` (drops one temp clone). No compression logic touched; spill semantics identical to `Vec` by construction.

## Tests

- Allocation matrix (release, counting allocator, pre-parsed docs outside counters): per-cell table below, deterministic counts.
- Byte-equivalence: same corpus built with/without the fix -> all index files hash-identical; 6 query shapes (Count/TopkCount/Topk/Intersection/Phrase/Union) return identical totals, doc sets, and bit-exact scores.
- Full suite green (33 integration + 91 doctests); clippy no new warnings; fmt clean.

## Performance

| cell | allocs | bytes | wall | peak RSS |
|---|---|---|---|---|
| 1K x 500tok | -13.1% | -2.6% | overlap | ~293MB both |
| 10K x 500tok | -13.1% | -8.6% | overlap (interleaved) | repeat-identical |
| 100K x 500tok | -13.1% | -10.7% | overlap | 592.08 vs 592.26MB |
| 10K sparse | -40.4% | -7.0% | -1.2% (noise) | 89.08 vs 88.97MB |

Method: baseline-vs-fixed binaries interleaved per cell (sequential batches were confounded by machine thermal drift — verified and discarded). No latency claim: allocator traffic only.

Out of scope: tokenizer rotation rework, commit buffer reuse.
