### PR TITLE
Simplify union_count counting; drop seed sort

### DIFF
--- a/seekstorm/src/union.rs
+++ b/seekstorm/src/union.rs
@@ -11,8 +11,8 @@ use crate::{
     search::{FilterSparse, Ranges, ResultType, SearchResult},
     single::{single_blockid, single_docid},
     utils::{
-        block_copy, read_f32, read_f64, read_i8, read_i16, read_i32, read_i64, read_u16, read_u32,
-        read_u64, write_u64,
+        read_f32, read_f64, read_i8, read_i16, read_i32, read_i64, read_u16, read_u32, read_u64,
+        write_u64,
     },
 };
 
@@ -814,13 +814,7 @@ pub(crate) async fn union_count<'a>(
     facet_filter: &[FilterSparse],
     block_id: usize,
 ) {
-    query_list.sort_unstable_by(|a, b| b.p_docid_count.partial_cmp(&a.p_docid_count).unwrap());
-
-    let first_valid_idx = query_list.iter().position(|plo| !plo.end_flag).unwrap_or(0);
-    let mut result_count_local = query_list[first_valid_idx].blocks
-        [query_list[first_valid_idx].p_block as usize]
-        .posting_count as u32
-        + 1;
+    let mut result_count_local = 0u32;
 
     let mut bitmap_0: [u8; 8192] = [0u8; 8192];
     let mut first_valid = true;
@@ -829,53 +823,32 @@ pub(crate) async fn union_count<'a>(
         if plo.end_flag {
             continue;
         }
+        let is_first = first_valid;
+        first_valid = false;
 
         if plo.compression_type == CompressionType::Bitmap {
-            if first_valid {
-                block_copy(
-                    plo.byte_array,
-                    plo.compressed_doc_id_range,
-                    &mut bitmap_0,
-                    0,
-                    8192,
-                );
-                first_valid = false;
-            } else {
-                for i in (0..8192).step_by(8) {
-                    let x1 = read_u64(&bitmap_0, i);
-                    let x2 = read_u64(&plo.byte_array[plo.compressed_doc_id_range..], i);
-                    result_count_local += u64::count_ones(!x1 & x2);
-                    write_u64(x1 | x2, &mut bitmap_0, i);
-                }
+            for i in (0..8192).step_by(8) {
+                let x1 = read_u64(&bitmap_0, i);
+                let x2 = read_u64(&plo.byte_array[plo.compressed_doc_id_range..], i);
+                result_count_local += u64::count_ones(!x1 & x2);
+                write_u64(x1 | x2, &mut bitmap_0, i);
             }
         } else if plo.compression_type == CompressionType::Array {
-            if first_valid {
-                for i in 0..plo.p_docid_count {
-                    let docid =
-                        read_u16(&plo.byte_array[plo.compressed_doc_id_range..], i * 2) as usize;
-                    let byte_index = docid >> 3;
-                    let bit_index = docid & 7;
+            for i in 0..plo.p_docid_count {
+                let docid =
+                    read_u16(&plo.byte_array[plo.compressed_doc_id_range..], i * 2) as usize;
+                let byte_index = docid >> 3;
+                let bit_index = docid & 7;
 
+                if bitmap_0[byte_index] & (1 << bit_index) == 0 {
                     bitmap_0[byte_index] |= 1 << bit_index;
-                }
-                first_valid = false;
-            } else {
-                for i in 0..plo.p_docid_count {
-                    let docid =
-                        read_u16(&plo.byte_array[plo.compressed_doc_id_range..], i * 2) as usize;
-                    let byte_index = docid >> 3;
-                    let bit_index = docid & 7;
-
-                    if bitmap_0[byte_index] & (1 << bit_index) == 0 {
-                        bitmap_0[byte_index] |= 1 << bit_index;
-                        result_count_local += 1;
-                    }
+                    result_count_local += 1;
                 }
             }
         } else {
             let runs_count = read_u16(&plo.byte_array[plo.compressed_doc_id_range..], 0) as i32;
 
-            if first_valid {
+            if is_first {
                 for ii in (1..(runs_count << 1) + 1).step_by(2) {
                     let startdocid = read_u16(
                         &plo.byte_array[plo.compressed_doc_id_range..],
@@ -886,15 +859,12 @@ pub(crate) async fn union_count<'a>(
                         (ii + 1) as usize * 2,
                     ) as usize;
 
+                    result_count_local += runlength as u32 + 1;
                     for j in 0..=runlength {
                         let docid = startdocid + j;
-                        let byte_index = docid >> 3;
-                        let bit_index = docid & 7;
-
-                        bitmap_0[byte_index] |= 1 << bit_index;
+                        bitmap_0[docid >> 3] |= 1 << (docid & 7);
                     }
                 }
-                first_valid = false;
             } else {
                 for ii in (1..(runs_count << 1) + 1).step_by(2) {
                     let startdocid = read_u16(

--- a/seekstorm/tests/union_count_plus_one.rs
+++ b/seekstorm/tests/union_count_plus_one.rs
@@ -1,0 +1,100 @@
+//! Same-block overlapping union must count exactly (pins the `+1` encoding).
+
+use seekstorm::commit::Commit;
+use seekstorm::index::{
+    AccessType, Close, Clustering, DocumentCompression, FrequentwordType, IndexArc, IndexDocuments,
+    IndexMetaObject, LexicalSimilarity, NgramSet, StemmerType, StopwordType, TokenizerType,
+    create_index,
+};
+use seekstorm::search::{QueryRewriting, QueryType, ResultType, Search, SearchMode};
+use seekstorm::vector::Inference;
+use std::{fs, path::Path};
+
+fn meta() -> IndexMetaObject {
+    IndexMetaObject {
+        id: 0,
+        name: "union_count_plus_one".into(),
+        lexical_similarity: LexicalSimilarity::Bm25f,
+        tokenizer: TokenizerType::UnicodeAlphanumeric,
+        stemmer: StemmerType::None,
+        stop_words: StopwordType::None,
+        frequent_words: FrequentwordType::None,
+        ngram_indexing: NgramSet::SingleTerm as u8,
+        document_compression: DocumentCompression::Snappy,
+        access_type: AccessType::Mmap,
+        spelling_correction: None,
+        query_completion: None,
+        clustering: Clustering::None,
+        inference: Inference::None,
+    }
+}
+
+fn schema() -> Vec<seekstorm::index::SchemaField> {
+    serde_json::from_str(
+        r#"[{"field":"title","field_type":"Text","store":true,"index_lexical":true}]"#,
+    )
+    .unwrap()
+}
+
+fn doc(title: &str) -> seekstorm::index::Document {
+    serde_json::from_str(&format!(r#"{{"title":"{title}"}}"#)).unwrap()
+}
+
+async fn search(
+    index: &IndexArc,
+    query: &str,
+    result_type: ResultType,
+) -> seekstorm::search::ResultObject {
+    index
+        .search(
+            query.into(),
+            None,
+            QueryType::Union,
+            SearchMode::Lexical,
+            false,
+            0,
+            100,
+            result_type,
+            false,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            QueryRewriting::SearchOnly,
+        )
+        .await
+}
+
+#[tokio::test]
+async fn union_count_overlap_same_block() {
+    let dir = "tests/index_union_plus_one/";
+    let path = Path::new(dir);
+    let _ = fs::remove_dir_all(path);
+    let index = create_index(path, meta(), &schema(), &Vec::new(), 11, true, Some(1))
+        .await
+        .unwrap();
+
+    // Overlapping docs: doc2, doc4 contain BOTH alpha and beta.
+    let docs = vec![
+        doc("alpha only item"),
+        doc("beta only item"),
+        doc("alpha beta both item"),
+        doc("alpha only item"),
+        doc("alpha beta both item"),
+        doc("beta only item"),
+    ];
+    index.index_documents(docs).await;
+    index.commit().await;
+
+    // 6 docs total in the same block; all contain at least one of alpha/beta.
+    let count = search(&index, "alpha beta", ResultType::Count).await;
+    let topk_count = search(&index, "alpha beta", ResultType::TopkCount).await;
+
+    let expected = 6;
+    println!("Count result: {}", count.result_count_total);
+    println!("TopkCount result: {}", topk_count.result_count_total);
+    assert_eq!(count.result_count_total, expected);
+    assert_eq!(topk_count.result_count_total, expected);
+
+    index.close().await;
+}


### PR DESCRIPTION
union_count seeded its total from the first-sorted term's posting_count and skipped counting for that term (block_copy / set-only first-term branches), with a per-block sort to pick the seed. OR-ing every valid term into the zeroed bitmap and counting only new bits needs no ordering, so the sort, the seed lookup, and the Bitmap/Array first-term branches are removed; Rle keeps a first-term branch counting runs analytically.

Tests: `union_count_plus_one` (same-block overlap counts exactly); `union_count_cross_block` and delete-consistency suites green.

Release Count bench, old vs new back-to-back (min, 50 warmup + 2x500 reps):

| query | old | new |
|---|---|---|
| XS-1k C40 (1000) | 36.6 | 37.2 |
| XS-1k C3 (75) | 2.4 | 2.4 |
| S-10k mixed (10800) | 19.9 | 19.5 |
| S-10k sparse (2800) | 6.4 | 6.1 |
| M-78k dense (70k) | 17.6 | 18.8 |
| M-78k sparse (1k) | 3.7 | 4.0 |
| M-78k mixed (60.6k) | 1.5 | 1.7 |
| L-300k dense (280k) | 135.0 | 135.1 |
| L-300k sparse (1300) | 5.1 | 4.8 |
| XL-914k dense (850k) | 93.0 | 84.9 |
| XL-914k sparse (3800) | 11.9 | 10.8 |